### PR TITLE
feat: auto theme

### DIFF
--- a/src/components/Theme/Theme.tsx
+++ b/src/components/Theme/Theme.tsx
@@ -6,8 +6,10 @@ import { useAppSelector } from "store";
 import { darkTheme, defaultTheme } from "assets/themes";
 
 export const Theme: FC = ({ children }) => {
+  const darkOS = window.matchMedia("(prefers-color-scheme: dark)").matches;
   const isDarkTheme = useAppSelector((state) => state.layout.isDarkTheme);
-  const theme = isDarkTheme ? darkTheme : defaultTheme;
+  const theme =
+    isDarkTheme === undefined ? (darkOS ? darkTheme : defaultTheme) : isDarkTheme ? darkTheme : defaultTheme;
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/pages/_layouts/Main/components/Header/Header.tsx
+++ b/src/pages/_layouts/Main/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import { IconButton, Toolbar, AppBar, Tooltip, Box, Avatar } from "@material-ui/
 import ExitToAppIcon from "@material-ui/icons/ExitToApp";
 import MoonIcon from "@material-ui/icons/Brightness3";
 import SunIcon from "@material-ui/icons/Brightness5";
+import AutoDarkIcon from "@material-ui/icons/BrightnessAuto";
 
 import { useAppSelector, useAppDispatch } from "store";
 import { toggleTheme } from "store/modules/layout";
@@ -21,7 +22,9 @@ export const Header: FC = () => {
   const isMobile = useMobile();
   const dispatch = useAppDispatch();
   const isDarkTheme = useAppSelector((state) => state.layout.isDarkTheme);
-  const ThemeIcon = useMemo(() => (isDarkTheme ? SunIcon : MoonIcon), [isDarkTheme]);
+  const ThemeIcon = useMemo(() => (isDarkTheme === undefined ? AutoDarkIcon : !isDarkTheme ? SunIcon : MoonIcon), [
+    isDarkTheme,
+  ]);
 
   return (
     <div className={classes.root}>
@@ -36,7 +39,7 @@ export const Header: FC = () => {
             </Tooltip>
           </Link>
           <Title />
-          <Tooltip title={isDarkTheme ? "Light Theme" : "Dark Theme"}>
+          <Tooltip title={isDarkTheme === undefined ? "Auto Theme" : !isDarkTheme ? "Light Theme" : "Dark Theme"}>
             <IconButton color="inherit" onClick={() => dispatch(toggleTheme())}>
               <ThemeIcon />
             </IconButton>

--- a/src/store/modules/layout/reducers.ts
+++ b/src/store/modules/layout/reducers.ts
@@ -6,7 +6,7 @@ export interface LayoutState {
   sidebar: {
     isOpen: boolean;
   };
-  isDarkTheme: boolean;
+  isDarkTheme?: boolean;
 }
 
 const INITIAL_STATE: LayoutState = {
@@ -28,7 +28,7 @@ export const reducers = createReducer(INITIAL_STATE, {
   [LayoutActionsTypes.THEME_TOGGLE]: (state) => {
     return {
       ...state,
-      isDarkTheme: !state.isDarkTheme,
+      isDarkTheme: state.isDarkTheme ? undefined : state.isDarkTheme === undefined ? false : true,
     };
   },
 });


### PR DESCRIPTION
## **Description** 📝
### Auto Theme
- The LayoutActionsTypes.THEME_TOGGLE reducer accepts an undefined value. So **true is the dark theme**, **false is the light theme** and **undefined is automatic** (defined by the browser)
- The same for the buttons, undefined is the automatic theme, true is the dark theme and false the light theme

## **Related Issue** ❗
- No issue

## **Motivation and Context** ⚓
- The latest versions of browsers have the dark and light theme. See documentation on how to identify the [dark theme the browser](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
## **How Has This Been Tested?** 💣
- Running the project and changing the theme in Microsoft Windows 10
![image](https://user-images.githubusercontent.com/13997871/90668641-c5991500-e226-11ea-92d2-c980389bf824.png)

## **Screenshots (if appropriate)** 📷
![image](https://user-images.githubusercontent.com/13997871/90668680-d184d700-e226-11ea-9cb2-4a1ed2782810.png)
